### PR TITLE
feat: :sparkles: Add options to filter the dataset.

### DIFF
--- a/custom_components/deutschebahn/config_flow.py
+++ b/custom_components/deutschebahn/config_flow.py
@@ -13,6 +13,8 @@ from .const import (  # pylint: disable=unused-import
     CONF_START,
     CONF_OFFSET,
     CONF_ONLY_DIRECT,
+    CONF_MAX_CONNECTIONS,
+    CONF_SELECTED_PRODUCTS,
 )
 DOMAIN = "deutschebahn"
 
@@ -43,6 +45,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_START): str,
                 vol.Required(CONF_DESTINATION): str,
                 vol.Required(CONF_OFFSET, default=0): cv.positive_int,
+                vol.Required(CONF_MAX_CONNECTIONS, default=2): cv.positive_int,
+                vol.Required(CONF_SELECTED_PRODUCTS, default="All"): str,
                 vol.Required(CONF_ONLY_DIRECT, default=False): cv.boolean,
             },
         )

--- a/custom_components/deutschebahn/const.py
+++ b/custom_components/deutschebahn/const.py
@@ -7,6 +7,15 @@ CONF_START = "start"
 CONF_OFFSET = "offset"
 CONF_ONLY_DIRECT = "only_direct"
 CONF_MAX_CONNECTIONS = "max_connections"
-CONF_SELECTED_PRODUCTS = "selected_products"
-
+CONF_IGNORED_PRODUCTS = "ignored_products"
+CONF_IGNORED_PRODUCTS_OPTIONS = {
+    "STR": "Straßenbahn (STR)",
+    "S": "Stadtbahn (S-Bahn)",
+    "RE": "Regional Express (RE)",
+    "RB": "Regional Bahn (RB)",
+    "EC": "EuroCity (EC)",
+    "IC": "Intercity (IC)",
+    "ICE": "Intercity Express (ICE)",
+    "TVG": "Train à grande vitesse (TVG)",
+}
 ATTR_DATA = "data"

--- a/custom_components/deutschebahn/const.py
+++ b/custom_components/deutschebahn/const.py
@@ -6,5 +6,7 @@ CONF_DESTINATION = "destination"
 CONF_START = "start"
 CONF_OFFSET = "offset"
 CONF_ONLY_DIRECT = "only_direct"
+CONF_MAX_CONNECTIONS = "max_connections"
+CONF_SELECTED_PRODUCTS = "selected_products"
 
 ATTR_DATA = "data"

--- a/custom_components/deutschebahn/sensor.py
+++ b/custom_components/deutschebahn/sensor.py
@@ -67,10 +67,8 @@ class DeutscheBahnSensor(SensorEntity):
         self.offset = timedelta(minutes=config[CONF_OFFSET])
         self.max_connections: int = config[CONF_MAX_CONNECTIONS]
         self.select_any_product: bool = any(
-            [
-                p.strip().upper() in ["*", "ALL", "ANY"]
-                for p in config[CONF_SELECTED_PRODUCTS]
-            ]
+            pattern in config[CONF_SELECTED_PRODUCTS].upper()
+            for pattern in ["*", "ALL", "ANY"]
         )
         self.selected_products: Set[str] = set(
             [

--- a/custom_components/deutschebahn/strings.json
+++ b/custom_components/deutschebahn/strings.json
@@ -8,7 +8,9 @@
           "start": "Start station",
           "destination": "Destination station",
           "offset": "Offset in minutes",
-          "only_direct": "Only show direct connections?"
+          "only_direct": "Only show direct connections?",
+          "max_connections": "Max connections in sensor",
+          "selected_products": "Product selection (comma seperated)"
         }
       }
     },

--- a/custom_components/deutschebahn/strings.json
+++ b/custom_components/deutschebahn/strings.json
@@ -8,7 +8,7 @@
           "offset": "Offset in minutes",
           "only_direct": "Only show direct connections?",
           "max_connections": "Max connections in sensor",
-          "selected_products": "Product selection (comma seperated)"
+          "ignored_products": "Products to ignore"
         }
       }
     }
@@ -24,7 +24,7 @@
           "offset": "Offset in minutes",
           "only_direct": "Only show direct connections?",
           "max_connections": "Max connections in sensor",
-          "selected_products": "Product selection (comma seperated)"
+          "ignored_products": "Products to ignore"
         }
       }
     },

--- a/custom_components/deutschebahn/strings.json
+++ b/custom_components/deutschebahn/strings.json
@@ -1,4 +1,18 @@
 {
+  "options": {
+    "flow_title": "Setup DB:{entity_name}",
+    "step": {
+      "init": {
+        "description": "Submit your train station details for the search queries.",
+        "data": {
+          "offset": "Offset in minutes",
+          "only_direct": "Only show direct connections?",
+          "max_connections": "Max connections in sensor",
+          "selected_products": "Product selection (comma seperated)"
+        }
+      }
+    }
+  },
   "config": {
     "flow_title": "Setup DeutscheBahn",
     "step": {

--- a/custom_components/deutschebahn/translations/de.json
+++ b/custom_components/deutschebahn/translations/de.json
@@ -8,7 +8,9 @@
           "start": "Start Station",
           "destination": "Ziel station",
           "offset": "Versatz in Minutes",
-          "only_direct": "Zeige nur direkte Verbindungen?"
+          "only_direct": "Zeige nur direkte Verbindungen?",
+          "max_connections": "Maximale Anzahle der angezeigten Verbindungen",
+          "selected_products": "Produktauswahl"
         }
       }
     },

--- a/custom_components/deutschebahn/translations/de.json
+++ b/custom_components/deutschebahn/translations/de.json
@@ -8,7 +8,7 @@
           "offset": "Versatz in Minutes",
           "only_direct": "Zeige nur direkte Verbindungen?",
           "max_connections": "Maximale Anzahle der angezeigten Verbindungen",
-          "selected_products": "Produktauswahl"
+          "ignored_products": "Zu ignorierende Produkte"
         }
       }
     }
@@ -24,7 +24,7 @@
           "offset": "Versatz in Minutes",
           "only_direct": "Zeige nur direkte Verbindungen?",
           "max_connections": "Maximale Anzahle der angezeigten Verbindungen",
-          "selected_products": "Produktauswahl"
+          "ignored_products": "Zu ignorierende Produkte"
         }
       }
     },

--- a/custom_components/deutschebahn/translations/de.json
+++ b/custom_components/deutschebahn/translations/de.json
@@ -1,4 +1,18 @@
 {
+  "options": {
+    "flow_title": "Einrichtung der:{entity_name}",
+    "step": {
+      "init": {
+        "description": "Trage hier deine Zug Station Informationen ein für die Suchabfrage.",
+        "data": {
+          "offset": "Versatz in Minutes",
+          "only_direct": "Zeige nur direkte Verbindungen?",
+          "max_connections": "Maximale Anzahle der angezeigten Verbindungen",
+          "selected_products": "Produktauswahl"
+        }
+      }
+    }
+  },
   "config": {
     "flow_title": "Einrichtung der DeutscheBahn Integration",
     "step": {

--- a/custom_components/deutschebahn/translations/en.json
+++ b/custom_components/deutschebahn/translations/en.json
@@ -8,7 +8,9 @@
           "start": "Start station",
           "destination": "Destination station",
           "offset": "Offset in minutes",
-          "only_direct": "Only show direct connections?"
+          "only_direct": "Only show direct connections?",
+          "max_connections": "Max connections in sensor",
+          "selected_products": "Product selection (comma seperated)"
         }
       }
     },

--- a/custom_components/deutschebahn/translations/en.json
+++ b/custom_components/deutschebahn/translations/en.json
@@ -8,7 +8,7 @@
           "offset": "Offset in minutes",
           "only_direct": "Only show direct connections?",
           "max_connections": "Max connections in sensor",
-          "selected_products": "Product selection (comma seperated)"
+          "ignored_products": "Products to ignore"
         }
       }
     }
@@ -24,7 +24,7 @@
           "offset": "Offset in minutes",
           "only_direct": "Only show direct connections?",
           "max_connections": "Max connections in sensor",
-          "selected_products": "Product selection (comma seperated)"
+          "ignored_products": "Products to ignore"
         }
       }
     },

--- a/custom_components/deutschebahn/translations/en.json
+++ b/custom_components/deutschebahn/translations/en.json
@@ -1,4 +1,18 @@
 {
+  "options": {
+    "flow_title": "Setup DB:{entity_name}",
+    "step": {
+      "init": {
+        "description": "Submit your train station details for the search queries.",
+        "data": {
+          "offset": "Offset in minutes",
+          "only_direct": "Only show direct connections?",
+          "max_connections": "Max connections in sensor",
+          "selected_products": "Product selection (comma seperated)"
+        }
+      }
+    }
+  },
   "config": {
     "flow_title": "Setup DeutscheBahn",
     "step": {


### PR DESCRIPTION
Hello @FaserF 

thanks for your integration!

For my own use case I needed to extent the functionality a bit.
And I thought maybe those changes could be beneficial to the community. 

I'm not quite sure if the config flow would need some sort of migration or if the defaults do suffice for that.
Any insight here would be greatly appreciated as this is my first work in the hassio ecosystem.

Currently the filter only apply to the data set and are not passed on to the actual "api" call as this is currently not supported.
But I assume the backend library needs a refresh in the future anyway as the DBahn is currently showing a warning to switch over to the new design, and therefore indirectly announces to discontinue this service.

# Proposed Changes

- **Allow connections list to be filtered by product**
I need to exclude ICE's from my filter list as those may not be covered by my ticket.
- **Set a maximum connection count to be available to a sensor**
To limit the data amount in the sensor. I'm not quite sure if this is currently a real concern, but may be for the internal caching.
- **Allow to access connections list in sensor**
I like to display a bit more data than only the next two departures.

## Related Issues

resolves FaserF/ha-deutschebahn#12
