### PR TITLE
update info for following trains

### DIFF
--- a/custom_components/deutschebahn/sensor.py
+++ b/custom_components/deutschebahn/sensor.py
@@ -106,10 +106,14 @@ class DeutscheBahnSensor(SensorEntity):
             if len(self.connections) > 1:
                 connections["next"] = self.connections[1]["departure"]
                 connections["next_delay"] = self.connections[1]["delay"]
+                connections["next_arrival"] = self.connections[1]["arrival"]
+                connections["next_arrival_delay"] = self.connections[2]["delay_arrival"]
                 connections["next_canceled"] = self.connections[1]["canceled"]
             if len(self.connections) > 2:
                 connections["next_on"] = self.connections[2]["departure"]
                 connections["next_on_delay"] = self.connections[2]["delay"]
+                connections["next_on_arrival"] = self.connections[2]["arrival"]
+                connections["next_on_arrival_delay"] = self.connections[2]["delay_arrival"]
                 connections["next_on_canceled"] = self.connections[2]["canceled"]
         else:
             connections = None


### PR DESCRIPTION
# Proposed Changes

> added next_arrival, next_arrival_delay, next_on_arrival and next_on_arrival_delay to use with lovelace card

## Related Issues

>

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
