### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/deutschebahn/sensor.py
+++ b/custom_components/deutschebahn/sensor.py
@@ -103,14 +103,12 @@ class DeutscheBahnSensor(SensorEntity):
         """Return the state attributes."""
         if len(self.connections) > 0:
             connections = self.connections[0].copy()
-            if len(self.connections) > 1:
-                connections["next"] = self.connections[1]["departure"]
-                connections["next_delay"] = self.connections[1]["delay"]
-                connections["next_canceled"] = self.connections[1]["canceled"]
-            if len(self.connections) > 2:
-                connections["next_on"] = self.connections[2]["departure"]
-                connections["next_on_delay"] = self.connections[2]["delay"]
-                connections["next_on_canceled"] = self.connections[2]["canceled"]
+            for cons in range(1,len(self.connections)):
+                if len(self.connections) > cons:
+                    connections[f"next_{cons}"] = self.connections[cons]["departure"]
+                    connections[f"next_{cons}_delay"] = self.connections[cons]["delay"]
+                    connections[f"next_{cons}_canceled"] = self.connections[cons]["canceled"]
+                    connections[f"next_{cons}_arrival"] = self.connections[cons]["arrival"]
         else:
             connections = None
         connections["departures"] = self.connections


### PR DESCRIPTION
# small refactorization of attribute setting

I´m not a 100% convinced of this solution, but it´s more flexible like this. Especially for attributes that can then be read in to Lovelace-cards like [Connection_card](https://github.com/silviokennecke/ha-custom-components/blob/main/components/public-transport/connection.card.js#L25). Maybe it´s worth finding a better name, but now i changed the attributes name "Next on" to "Next 1" etc.

It´s up to you to decide on this change.


Alternatively, one could have manually inserted the following to make the "arrival" attribute available quickly:

```connections["next_arrival"] = self.connections[1]["arrival"]```

But with the proposed solution is automatically set for all connections directly.

## Related Issues


