### PR TITLE
Make db integration superseded

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
+# SUPERSEDED INFORMATION!
+[superior integration](https://github.com/FaserF/ha-db_infoscreen) has been released which brings similar functionality from a different and more reliable api source. 
+
 # BREAKING WARNING!!!
-Unfortunatly bahn.de has shut down their websites that this integration used for web scraping. Therefore this integration wont work anymore since 15th december 2024. [More details](https://github.com/kennell/schiene/pull/36#issuecomment-2546101589) & [here](https://github.com/FaserF/ha-deutschebahn/issues/59#issuecomment-2546087237). Until a new method has found this integration wont work anymore. There is NO ETA. Work is being done [here](https://github.com/FaserF/ha-deutschebahn/pull/60).
+Obsolete due to [superior integration](https://github.com/FaserF/ha-db_infoscreen).
 
-I recommend switching to those integrations for now:
-
-- [hacs-hafas by @klimnik](https://github.com/akloeckner/hacs-hafas)
-
-- [MVG (for Munich) by @danielpotthast](https://github.com/danielpotthast/mvg)
-
+Unfortunatly bahn.de has shut down their websites that this integration used for web scraping. Therefore this integration wont work anymore since 15th december 2024. [More details](https://github.com/kennell/schiene/pull/36#issuecomment-2546101589) & [here](https://github.com/FaserF/ha-deutschebahn/issues/59#issuecomment-2546087237).
 
 # Deutsche Bahn Homeassistant Sensor
 The `deutschebahn` sensor will give you the departure time of the next train for the given connection. In case of a delay, the delay is also shown. Additional details are used to inform about, e.g., the type of the train, price, and if it is on time.

--- a/custom_components/deutschebahn/manifest.json
+++ b/custom_components/deutschebahn/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "schiene==0.26"
   ],
-  "version": "3.0.5"
+  "version": "3.0.6"
 }

--- a/custom_components/deutschebahn/sensor.py
+++ b/custom_components/deutschebahn/sensor.py
@@ -139,7 +139,7 @@ class DeutscheBahnSensor(SensorEntity):
     async def async_update(self):
         """Skip updates and log a warning."""
         _LOGGER.warning(
-            "Skipping update for DeutscheBahn sensor '%s' due to known issues with the data source: https://github.com/FaserF/ha-deutschebahn?tab=readme-ov-file#breaking-warning"
+            "Skipping update for DeutscheBahn sensor '%s'. Please switch to superior integration: https://github.com/FaserF/ha-db_infoscreen"
             % self._name
         )
 

--- a/custom_components/deutschebahn/strings.json
+++ b/custom_components/deutschebahn/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "Setup DB:{entity_name}",
     "step": {
       "init": {
-        "description": "Submit your train station details for the search queries.",
+        "description": "Please switch to this integration: https://github.com/FaserF/ha-db_infoscreen",
         "data": {
           "offset": "Offset in minutes",
           "only_direct": "Only show direct connections?",
@@ -18,7 +18,7 @@
     "flow_title": "Setup DeutscheBahn",
     "step": {
       "user": {
-        "description": "Submit your train station details for the search queries.",
+        "description": "Please switch to this integration: https://github.com/FaserF/ha-db_infoscreen",
         "data": {
           "start": "Start station",
           "destination": "Destination station",

--- a/custom_components/deutschebahn/translations/de.json
+++ b/custom_components/deutschebahn/translations/de.json
@@ -3,7 +3,7 @@
     "flow_title": "Einrichtung der:{entity_name}",
     "step": {
       "init": {
-        "description": "Trage hier deine Zug Station Informationen ein für die Suchabfrage.",
+        "description": "Bitte wechsle zu dieser Integration: https://github.com/FaserF/ha-db_infoscreen",
         "data": {
           "offset": "Versatz in Minuten",
           "only_direct": "Nur direkte Verbindungen anzeigen?",
@@ -18,7 +18,7 @@
     "flow_title": "Einrichtung der DeutscheBahn Integration",
     "step": {
       "user": {
-        "description": "Trage hier deine Zug Station Informationen ein für die Suchabfrage.",
+        "description": "Bitte wechsle zu dieser Integration: https://github.com/FaserF/ha-db_infoscreen",
         "data": {
           "start": "Startstation",
           "destination": "Zielstation",

--- a/custom_components/deutschebahn/translations/en.json
+++ b/custom_components/deutschebahn/translations/en.json
@@ -3,7 +3,7 @@
     "flow_title": "Setup DB:{entity_name}",
     "step": {
       "init": {
-        "description": "Submit your train station details for the search queries.",
+        "description": "Please switch to this integration: https://github.com/FaserF/ha-db_infoscreen",
         "data": {
           "offset": "Offset in minutes",
           "only_direct": "Only show direct connections?",
@@ -18,7 +18,7 @@
     "flow_title": "Setup DeutscheBahn",
     "step": {
       "user": {
-        "description": "Submit your train station details for the search queries.",
+        "description": "Please switch to this integration: https://github.com/FaserF/ha-db_infoscreen",
         "data": {
           "start": "Start station",
           "destination": "Destination station",


### PR DESCRIPTION
# Proposed Changes

This will make the ha-deutschebahn superseded by https://github.com/FaserF/ha-db_infoscreen

This will be the last change to this integration, everything new will be done at the new and better integration. 

## Related Issues
#59
#60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README.md to highlight integration obsolescence
  - Added warning about current integration's limitations

- **Configuration**
  - Updated version to 3.0.6
  - Modified configuration descriptions in multiple language files

- **Guidance**
  - Directed users to switch to alternative integration (ha-db_infoscreen)
  - Removed previous setup instructions for train station details

- **Logging**
  - Updated warning messages in sensor update method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->